### PR TITLE
Transpile files during imports discovery phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ const results = await babelTiming(['path/to/file.js'], options);
 #### `babelConfig` / `--babel-config`
 
 Type: `string | false`<br />
-Default: `false`
+Default: `undefined`
 
 Path to a custom [babel configuration file](https://babeljs.io/docs/en/options#configfile). By default Babel will try to load any existing valid configuration file.
 

--- a/__fixtures__/.babelrc
+++ b/__fixtures__/.babelrc
@@ -1,7 +1,6 @@
 {
   "presets": [
-    [
-      "@babel/preset-env"
-    ]
+    "@babel/preset-react",
+    "@babel/preset-env"
   ]
 }

--- a/__fixtures__/file-3.jsx
+++ b/__fixtures__/file-3.jsx
@@ -1,0 +1,1 @@
+export default <Foo />;

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,6 +74,16 @@
         "@babel/types": "^7.0.0"
       }
     },
+    "@babel/helper-builder-react-jsx": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.3.0.tgz",
+      "integrity": "sha512-MjA9KgwCuPEkQd9ncSXvSyJ5y+j2sICHyrI0M3L+6fnS4wMSNDc1ARXsbTfbb2cXHn17VisSnU/sHFTCxVxSMw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.3.0",
+        "esutils": "^2.0.0"
+      }
+    },
     "@babel/helper-call-delegate": {
       "version": "7.4.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.4.0.tgz",
@@ -146,7 +156,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
       "integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.0.0"
       }
@@ -334,6 +343,15 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.2.0.tgz",
       "integrity": "sha512-5UGYnMSLRE1dqqZwug+1LISpA403HzlSfsg6P9VXU6TBjcSHeNlw4DxDx7LgpF+iKZoOG/+uzqoRHTdcUpiZNg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-jsx": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.2.0.tgz",
+      "integrity": "sha512-VyN4QANJkRW6lDBmENzRszvZf3/4AXaj9YR7GwrWeeN9tEBPuXbmDYVU9bYBN0D70zCWVwUy0HWq2553VCb6Hw==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -586,6 +604,46 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
+    "@babel/plugin-transform-react-display-name": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.2.0.tgz",
+      "integrity": "sha512-Htf/tPa5haZvRMiNSQSFifK12gtr/8vwfr+A9y69uF0QcU77AVu4K7MiHEkTxF7lQoHOL0F9ErqgfNEAKgXj7A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-react-jsx": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.3.0.tgz",
+      "integrity": "sha512-a/+aRb7R06WcKvQLOu4/TpjKOdvVEKRLWFpKcNuHhiREPgGRB4TQJxq07+EZLS8LFVYpfq1a5lDUnuMdcCpBKg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-builder-react-jsx": "^7.3.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-jsx": "^7.2.0"
+      }
+    },
+    "@babel/plugin-transform-react-jsx-self": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.2.0.tgz",
+      "integrity": "sha512-v6S5L/myicZEy+jr6ielB0OR8h+EH/1QFx/YJ7c7Ua+7lqsjj/vW6fD5FR9hB/6y7mGbfT4vAURn3xqBxsUcdg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-jsx": "^7.2.0"
+      }
+    },
+    "@babel/plugin-transform-react-jsx-source": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.2.0.tgz",
+      "integrity": "sha512-A32OkKTp4i5U6aE88GwwcuV4HAprUgHcTq0sSafLxjr6AW0QahrCRCjxogkbbcdtpbXkuTOlgpjophCxb6sh5g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-jsx": "^7.2.0"
+      }
+    },
     "@babel/plugin-transform-regenerator": {
       "version": "7.4.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.3.tgz",
@@ -716,6 +774,19 @@
         "invariant": "^2.2.2",
         "js-levenshtein": "^1.1.3",
         "semver": "^5.5.0"
+      }
+    },
+    "@babel/preset-react": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.0.0.tgz",
+      "integrity": "sha512-oayxyPS4Zj+hF6Et11BwuBkmpgT/zMxyuZgFrMeZID6Hdh3dGlk4sHCAhdBCpuCKW2ppBfl2uCCetlrUIJRY3w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-transform-react-display-name": "^7.0.0",
+        "@babel/plugin-transform-react-jsx": "^7.0.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.0.0",
+        "@babel/plugin-transform-react-jsx-source": "^7.0.0"
       }
     },
     "@babel/template": {
@@ -2419,6 +2490,22 @@
           "requires": {
             "is-extendable": "^0.1.0"
           }
+        }
+      }
+    },
+    "find-babel-config": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-1.2.0.tgz",
+      "integrity": "sha512-jB2CHJeqy6a820ssiqwrKMeyC6nNdmrcgkKWJWmpoxpE8RKciYJXCcXRq1h2AzCo5I5BJeN2tkGEO3hLTuePRA==",
+      "requires": {
+        "json5": "^0.5.1",
+        "path-exists": "^3.0.0"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+          "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
         }
       }
     },
@@ -5320,8 +5407,7 @@
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-      "dev": true
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -5788,6 +5874,15 @@
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
           "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA=="
         }
+      }
+    },
+    "rollup-plugin-babel": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-babel/-/rollup-plugin-babel-4.3.2.tgz",
+      "integrity": "sha512-KfnizE258L/4enADKX61ozfwGHoqYauvoofghFJBhFnpH9Sb9dNPpWg8QHOaAfVASUYV8w0mCx430i9z0LJoJg==",
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "rollup-pluginutils": "^2.3.0"
       }
     },
     "rollup-plugin-commonjs": {

--- a/package.json
+++ b/package.json
@@ -36,16 +36,19 @@
     "cli-table": "^0.3.1",
     "colors": "^1.3.3",
     "commander": "^2.20.0",
+    "find-babel-config": "^1.2.0",
     "glob": "^7.1.3",
     "lodash.mergewith": "^4.6.1",
     "multimatch": "^4.0.0",
     "reduce-flatten": "^2.0.0",
     "rollup": "^1.10.1",
+    "rollup-plugin-babel": "^4.3.2",
     "rollup-plugin-commonjs": "^9.3.4",
     "rollup-plugin-node-resolve": "^4.2.3"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.4.3",
+    "@babel/preset-react": "^7.0.0",
     "husky": "^1.0.0",
     "jest": "^24.7.1",
     "lint-staged": "^7.0.0",
@@ -70,5 +73,7 @@
       "git add"
     ]
   },
-  "engines" : { "node" : ">=7.6" }
+  "engines": {
+    "node": ">=7.6"
+  }
 }

--- a/src/__tests__/babelTiming.test.js
+++ b/src/__tests__/babelTiming.test.js
@@ -31,7 +31,7 @@ describe('babelTiming', () => {
   });
 
   it('entries are sorted by decreasing "totalTime"', async () => {
-    const results = await babelTiming([path.join(FIXTURES, 'file-*.js')]);
+    const results = await babelTiming([path.join(FIXTURES, 'file-*.js*')]);
     let previous = Infinity;
 
     results.forEach(entry => {
@@ -42,7 +42,7 @@ describe('babelTiming', () => {
 
   describe('"expandPlugins" option', () => {
     it('results have expected shape', async () => {
-      const results = await babelTiming([path.join(FIXTURES, 'file-*.js')], {
+      const results = await babelTiming([path.join(FIXTURES, 'file-*.js*')], {
         expandPlugins: true,
       });
       const resultsEntry = results[0];
@@ -50,7 +50,7 @@ describe('babelTiming', () => {
     });
 
     it('plugins data entries are sorted by decreasing "time"', async () => {
-      const results = await babelTiming([path.join(FIXTURES, 'file-*.js')], {
+      const results = await babelTiming([path.join(FIXTURES, 'file-*.js*')], {
         expandPlugins: true,
       });
       const resultsEntry = results[0];
@@ -65,7 +65,7 @@ describe('babelTiming', () => {
 
   describe('glob patterns', () => {
     it('returns results matching expected pattern', async () => {
-      const results = await babelTiming([path.join(FIXTURES, 'file-*.js')]);
+      const results = await babelTiming([path.join(FIXTURES, 'file-*.js*')]);
       expect(results.length).toBe(3);
     });
   });

--- a/src/babelTiming.js
+++ b/src/babelTiming.js
@@ -12,7 +12,7 @@ const joinSamePackageResults = require('./joinSamePackageResults');
 async function babelTiming(
   filePatterns = [],
   {
-    babelConfig = false,
+    babelConfig,
     followImports = false,
     include = ['**'],
     exclude = ['**/node_modules/**'],
@@ -29,7 +29,13 @@ async function babelTiming(
   if (followImports) {
     let importedFiles = await Promise.all(
       files.map(file =>
-        getImports(file, {resolveMainFields, include, exclude, verbose})
+        getImports(file, {
+          babelConfig,
+          resolveMainFields,
+          include,
+          exclude,
+          verbose,
+        })
       )
     );
 

--- a/src/getImports.js
+++ b/src/getImports.js
@@ -1,22 +1,44 @@
+const path = require('path');
 const rollup = require('rollup');
 const commonjs = require('rollup-plugin-commonjs');
 const nodeResolve = require('rollup-plugin-node-resolve');
+const babel = require('rollup-plugin-babel');
+const findBabelConfig = require('find-babel-config');
 const {onlyUnique} = require('./utils');
+const defaultExtensions = ['.js', '.jsx', '.mjs', '.ts', '.json'];
 
+/*
+ * @NOTE Even though we only need to discover the import tree of the
+ * provided file, we still have to transpile in case files syntax
+ * prevent Rollup from parsing
+ *
+ * @TODO consider using Rollup to run "wrapPluginVisitorMethod" method
+ */
 async function getImports(file, options) {
+  // Even though rollup-plugin-babel can autodiscover Babel configurations,
+  // here we want to use the same babel config for every module
+  const babelConfig =
+    options.babelConfig || findBabelConfig.sync(path.dirname(file)).file;
+
   // https://rollupjs.org/guide/en#rollup-rollup
   const inputOptions = {
     external: [],
     input: file,
     plugins: [
       nodeResolve({
-        extensions: ['.js', '.jsx', '.mjs', '.ts', '.json'],
+        extensions: defaultExtensions,
         mainFields: options.resolveMainFields,
+      }),
+      babel({
+        include: options.include,
+        exclude: options.exclude,
+        extensions: defaultExtensions,
+        configFile: babelConfig,
       }),
       commonjs({
         include: options.include,
         exclude: options.exclude,
-        extensions: ['.js', '.jsx', '.mjs', '.ts', '.json'],
+        extensions: defaultExtensions,
         sourceMap: false,
       }),
     ],


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behaviour?

Rollup can't parse files with special syntax (eg: typescript, JSX...) during imports discovery phase.

## What is the new behaviour?

Configure Rollup to transpile files.

## Does this PR introduce a breaking change?

No

## Other information:

## Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [X] Docs have been added / updated
